### PR TITLE
Prevent crash if a material is None

### DIFF
--- a/io_scene_g3d/g3d_exporter.py
+++ b/io_scene_g3d/g3d_exporter.py
@@ -212,7 +212,7 @@ class G3DBaseExporterOperator(ExportHelper, IOG3DOrientationHelper):
                 continue
 
             for blMaterialIndex in range(0, len(currentBlMesh.materials)):
-                if currentBlMesh.materials[blMaterialIndex].type != 'SURFACE':
+                if currentBlMesh.materials[blMaterialIndex] is None or currentBlMesh.materials[blMaterialIndex].type != 'SURFACE':
                     Util.debug("Ignoring mesh part for material '{!s}', type is not SURFACE (is {!s})", currentBlMesh.materials[blMaterialIndex].name, currentBlMesh.materials[blMaterialIndex].type)
                 else:
                     Util.debug("Processing mesh part for material '{!s}'", currentBlMesh.materials[blMaterialIndex].name)


### PR DESCRIPTION
It's possible for there to be None materials in the list of materials. If there are any materials that are None, this crashes when checking that the type is 'SURFACE'. This adds the same check as on line 422